### PR TITLE
allows number to be a valid quantity type

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -85,7 +85,7 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                 }
 
                 # Although the kubernetes api does not allow `number`  as valid
-                #  Quantity type - almost all kubenetes tooling
+                # Quantity type - almost all kubenetes tooling
                 # recognizes it is valid. For this reason, we extend the API definition to
                 # allow `number` values.
                 definitions["io.k8s.apimachinery.pkg.api.resource.Quantity"] = {

--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -83,8 +83,13 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                 definitions["io.k8s.apimachinery.pkg.util.intstr.IntOrString"] = {
                     "oneOf": [{"type": "string"}, {"type": "integer"}]
                 }
+
+                # Although the kubernetes api does not allow `number`  as valid
+                #  Quantity type - almost all kubenetes tooling
+                # recognizes it is valid. For this reason, we extend the API definition to
+                # allow `number` values.
                 definitions["io.k8s.apimachinery.pkg.api.resource.Quantity"] = {
-                    "oneOf": [{"type": "string"}, {"type": "integer"}]
+                    "oneOf": [{"type": "string"}, {"type": "integer"}, {"type": "number"}
                 }
 
                 # For Kubernetes, populate `apiVersion` and `kind` properties from `x-kubernetes-group-version-kind`


### PR DESCRIPTION
Allows fields of type `io.k8s.apimachinery.pkg.api.resource.Quantity"` to be of type `number` 

Per https://github.com/instrumenta/kubeval/issues/161