### PR TITLE
remove integer type from oneof

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -83,17 +83,12 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                 definitions["io.k8s.apimachinery.pkg.util.intstr.IntOrString"] = {
                     "oneOf": [{"type": "string"}, {"type": "integer"}]
                 }
-
                 # Although the kubernetes api does not allow `number`  as valid
                 # Quantity type - almost all kubenetes tooling
                 # recognizes it is valid. For this reason, we extend the API definition to
                 # allow `number` values.
                 definitions["io.k8s.apimachinery.pkg.api.resource.Quantity"] = {
-                    "oneOf": [
-                        {"type": "string"},
-                        {"type": "integer"},
-                        {"type": "number"},
-                    ]
+                    "oneOf": [{"type": "string"}, {"type": "number"}]
                 }
 
                 # For Kubernetes, populate `apiVersion` and `kind` properties from `x-kubernetes-group-version-kind`
@@ -103,7 +98,8 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                         for kube_ext in type_def["x-kubernetes-group-version-kind"]:
                             if expanded and "apiVersion" in type_def["properties"]:
                                 api_version = (
-                                    kube_ext["group"] + "/" + kube_ext["version"]
+                                    kube_ext["group"] + "/" +
+                                    kube_ext["version"]
                                     if kube_ext["group"]
                                     else kube_ext["version"]
                                 )
@@ -119,7 +115,8 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
                                 )
             if strict:
                 definitions = additional_properties(definitions)
-            definitions_file.write(json.dumps({"definitions": definitions}, indent=2))
+            definitions_file.write(json.dumps(
+                {"definitions": definitions}, indent=2))
 
     types = []
 
@@ -187,7 +184,8 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
 
             if stand_alone:
                 base = "file://%s/%s/" % (os.getcwd(), output)
-                specification = JsonRef.replace_refs(specification, base_uri=base)
+                specification = JsonRef.replace_refs(
+                    specification, base_uri=base)
 
             if "additionalProperties" in specification:
                 if specification["additionalProperties"]:


### PR DESCRIPTION
Removes the `integer` schema from the `io.k8s.apimachinery.pkg.api.resource.Quantity` patch.

The `jsonschema` spec denotes that the `number` type is a superset of `integer`. Thus, this `oneOf` will always fail if given an integer, as it satisfies two types.

Verified by running `kubeval` against the schemas generated by this patch:

```console
./bin/kubeval service.yaml --schema-location file:///Users/brendanjryan/projects/kubernetes-json-schema
The file service.yaml contains a valid CronJob
```

```yaml
apiVersion: batch/v2alpha1
kind: CronJob
metadata:
  name: "sample-cron"
spec:
  schedule: "0 1 * * *" # daily at 1am pacific time
  successfulJobsHistoryLimit: 3
  failedJobsHistoryLimit: 3
  jobTemplate:
    spec:
      template:
        spec:
          containers:
            - name: "my_app"
              resources:
                requests:
                  cpu: 0.1
                  memory: "1500Mi"
                limits:
                  cpu: 2
                  memory: "2000Mi"
```