### PR TITLE
Issue #32: Windows: urlopen error

### DIFF
--- a/openapi2jsonschema/command.py
+++ b/openapi2jsonschema/command.py
@@ -183,7 +183,12 @@ def default(output, schema, prefix, stand_alone, expanded, kubernetes, strict):
             specification = updated
 
             if stand_alone:
-                base = "file://%s/%s/" % (os.getcwd(), output)
+                ###base = "file://%s/%s/" % (os.getcwd(), output)
+                if os.name == 'nt':
+                    base = "file:///%s/%s/" % (os.getcwd(), output)
+                else:
+                    base = "file://%s/%s/" % (os.getcwd(), output)
+
                 specification = JsonRef.replace_refs(
                     specification, base_uri=base)
 


### PR DESCRIPTION
For windows local path the base_uri parameter of JsonRef.replace_refs(...) requires three slashes i.e. file:///d:\mydir\subdir...